### PR TITLE
Changed gcc standard version to c90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC = gcc -std=c90
 CFLAGS = -g -fcommon
 LEX = lex
 YACC = yacc


### PR DESCRIPTION
The new version after c99 is giving implicit errors as a solution to that we are fixing the standard version to c90.